### PR TITLE
use os /tmp dir for creating code temp files

### DIFF
--- a/openassessment/xblock/job_sample_grader/job_sample_test_grader.py
+++ b/openassessment/xblock/job_sample_grader/job_sample_test_grader.py
@@ -25,7 +25,7 @@ class TestGrader:
         'c++': 'cpp'
     }
     __SECRET_DATA_DIR__ = "/grader_data/"
-    __TMP_DATA_DIR__ = os.path.dirname(__file__) + "/tmp_data/"
+    __TMP_DATA_DIR__ = "/tmp/"
 
     def grade(self, response, add_staff_cases=False):
         problem_name = response['problem_name']


### PR DESCRIPTION
### Description
OS tmp directory has the required permissions for the app to write there temporarily. With this, there will be no need to set up write permissions for temporary code after each deployment. Note that this is a temporary change. The file creation part will soon be moved to tempfile module.