### PR TITLE
Add labels feature to ORA block (LT-183)

### DIFF
--- a/openassessment/templates/openassessmentblock/edit/oa_edit.html
+++ b/openassessment/templates/openassessmentblock/edit/oa_edit.html
@@ -46,6 +46,28 @@
                 <li class="openassessment_date_editor field comp-setting-entry">
                     <div class="wrapper-comp-setting">
                         <label
+                            for="openassessment_labels_editor"
+                            class="setting-label">
+                            {% trans "Labels" %}
+                        </label>
+                        <input
+                            type="text"
+                            class="input setting-input"
+                            id="openassessment_labels_editor"
+                            value="{{ labels }}"
+                        >
+                    </div>
+                    <p class="setting-help">
+                        {% trans "A comma-separated list of label strings that can be used to categorize a problem. For example, oop, problem solving, dsa, etc." %}
+                        <br /> {% trans "Rules:" %}
+                        <br /> - {% trans "Only lower case alphabets [a-z]." %}
+                        <br /> - {% trans "Special character &lt;space&gt; is allowed." %}
+                        <br /> - {% trans "Use \",\" to separate labels." %}
+                    </p>
+                </li>
+                <li class="openassessment_date_editor field comp-setting-entry">
+                    <div class="wrapper-comp-setting">
+                        <label
                             for="openassessment_submission_start_date"
                             class="setting-label">
                             {% trans "Response Start Date" %}

--- a/openassessment/xblock/defaults.py
+++ b/openassessment/xblock/defaults.py
@@ -158,3 +158,5 @@ DEFAULT_EDITOR_ASSESSMENTS_ORDER = [
     "self-assessment",
     "staff-assessment",
 ]
+
+DEFAULT_LABEL_LIST = list()

--- a/openassessment/xblock/schema.py
+++ b/openassessment/xblock/schema.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import dateutil
 from pytz import utc
 import six
+import re
 
 from voluptuous import All, Any, In, Invalid, Range, Required, Schema
 
@@ -59,6 +60,31 @@ def datetime_validator(value):
         raise Invalid(u"Could not parse datetime from value \"{val}\"".format(val=value))
 
 
+def labels_validator(value):
+    """
+    Validate and sanitize labels string.
+
+    Args:
+        value: The value to validate.
+    
+    Returns:
+        unicode: The validated value.
+
+    Raises:
+        Invalid
+    """
+    if value is None or value.strip() == "":
+        return ""
+    else:
+        match = re.search(r"((?![a-z ,]).)+", value)
+        if bool(match):
+            raise Invalid(u"Labels contains character that is not allowed: {} ".format(
+                match.group()
+            ))
+
+    return value
+
+
 PROMPTS_TYPES = [
     u'text',
     u'html',
@@ -94,6 +120,7 @@ EDITOR_UPDATE_SCHEMA = Schema({
     ],
     Required('prompts_type', default='text'): Any(All(utf8_validator, In(PROMPTS_TYPES)), None),
     Required('title'): utf8_validator,
+    Required('labels'): All(utf8_validator, labels_validator),
     Required('feedback_prompt'): utf8_validator,
     Required('feedback_default_text'): utf8_validator,
     Required('submission_start'): Any(datetime_validator, None),

--- a/openassessment/xblock/static/js/src/oa_server.js
+++ b/openassessment/xblock/static/js/src/oa_server.js
@@ -438,6 +438,7 @@ if (typeof OpenAssessment.Server === "undefined" || !OpenAssessment.Server) {
          *     fileTypeWhiteList (string): Comma separated file type white list
          *     latexEnabled: TRUE if latex rendering is enabled.
          *     leaderboardNum (int): The number of scores to show in the leaderboard.
+         *     labels (string): A string with comma-separated values.
          *
          * @returns {promise} A JQuery promise, which resolves with no arguments
          *     and fails with an error message.
@@ -450,6 +451,7 @@ if (typeof OpenAssessment.Server === "undefined" || !OpenAssessment.Server) {
                 feedback_prompt: options.feedbackPrompt,
                 feedback_default_text: options.feedback_default_text,
                 title: options.title,
+                labels: options.labels,
                 submission_start: options.submissionStart,
                 submission_due: options.submissionDue,
                 criteria: options.criteria,

--- a/openassessment/xblock/static/js/src/studio/oa_edit.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit.js
@@ -198,6 +198,7 @@ OpenAssessment.StudioView.prototype = {
             feedback_default_text: view.rubricView.feedback_default_text(),
             criteria: view.rubricView.criteriaDefinition(),
             title: view.settingsView.displayName(),
+            labels: view.settingsView.labels(),
             submissionStart: view.settingsView.submissionStart(),
             submissionDue: view.settingsView.submissionDue(),
             assessments: view.settingsView.assessmentsDescription(),

--- a/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
+++ b/openassessment/xblock/static/js/src/studio/oa_edit_settings.js
@@ -57,6 +57,16 @@ OpenAssessment.EditSettingsView = function(element, assessmentViews, data) {
         {min: 0, max: 100}
     );
 
+    this.labelsInputField = new OpenAssessment.InputControl(
+        $('#openassessment_labels_editor', this.element),
+        function(value) {
+            if (/((?![a-z ,]).)+/g.test(value)){
+                return ['Labels do not follow all the format rules.'];
+            }
+            return [];
+        }
+    );
+
     this.fileTypeWhiteListInputField = new OpenAssessment.InputControl(
         $('#openassessment_submission_white_listed_file_types', this.element),
         function(value) {
@@ -137,6 +147,21 @@ OpenAssessment.EditSettingsView.prototype = {
         var sel = $('#openassessment_title_editor', this.settingsElement);
         return OpenAssessment.Fields.stringField(sel, name);
     },
+
+    /**
+    Get or set the labels of the problem.
+
+    Args:
+        labels (string, optional): If provided, set the labels (a string with comma-separated values).
+
+    Returns:
+        string
+
+    **/
+   labels: function(labels) {
+    var sel = $('#openassessment_labels_editor', this.settingsElement);
+    return OpenAssessment.Fields.stringField(sel, labels);
+},
 
     /**
     Get or set the submission start date.
@@ -361,6 +386,7 @@ OpenAssessment.EditSettingsView.prototype = {
         isValid = (this.startDatetimeControl.validate() && isValid);
         isValid = (this.dueDatetimeControl.validate() && isValid);
         isValid = (this.leaderboardIntField.validate() && isValid);
+        isValid = (this.labelsInputField.validate() && isValid);
         if (this.fileUploadType() === 'custom') {
             isValid = (this.fileTypeWhiteListInputField.validate() && isValid);
         } else {
@@ -420,6 +446,7 @@ OpenAssessment.EditSettingsView.prototype = {
         this.dueDatetimeControl.clearValidationErrors();
         this.leaderboardIntField.clearValidationErrors();
         this.fileTypeWhiteListInputField.clearValidationErrors();
+        this.labelsInputField.clearValidationErrors();
         $.each(this.assessmentViews, function() {
             this.clearValidationErrors();
         });

--- a/openassessment/xblock/studio_mixin.py
+++ b/openassessment/xblock/studio_mixin.py
@@ -105,7 +105,7 @@ class StudioMixin(object):
             dict with keys
                 'rubric' (unicode), 'prompt' (unicode), 'title' (unicode),
                 'submission_start' (unicode),  'submission_due' (unicode),
-                'assessments (dict)
+                'assessments' (dict), 'labels' (unicode)
 
         """
         # In the authoring GUI, date and time fields should never be null.
@@ -142,6 +142,7 @@ class StudioMixin(object):
             'title': self.title,
             'submission_due': submission_due,
             'submission_start': submission_start,
+            'labels': self.labels,
             'assessments': assessments,
             'criteria': criteria,
             'feedbackprompt': self.rubric_feedback_prompt,
@@ -246,6 +247,7 @@ class StudioMixin(object):
         self.submission_due = data['submission_due']
         self.text_response = data['text_response']
         self.file_upload_response = data['file_upload_response']
+        self.labels = data['labels']
         if data['file_upload_response']:
             self.file_upload_type = data['file_upload_type']
             self.white_listed_file_types_string = data['white_listed_file_types']


### PR DESCRIPTION
A coding question requires tags/labels, for example, OOP, DSA, math, etc. These tags/labels are required for future features and enhancements.

This pull request introduces a `label_list` field and a `labels` property in the `openassessmentblock`. The `labels` property works with a string of **comma-separated values** and stores them in `label_list`. The ability to edit these labels through the block's edit view's setting tab has also been added. 

Associated Jira Ticket: [LT-183](https://arbisoft-assessment.atlassian.net/browse/LT-183?atlOrigin=eyJpIjoiNWY2NTlmZDhjMzk4NGVlMmFhMTYzNzMzOTZkM2ZlYzQiLCJwIjoiaiJ9)

> The name `labels` was chosen over `tags` because the XBlock class already has a [tags field](https://github.com/edx/XBlock/blob/1af0c970c20895276d75fc26501f60c98f434e3e/xblock/core.py#L127).


Edit view for the block:
<img width="834" alt="LT-183-studio-view" src="https://user-images.githubusercontent.com/71316217/112332603-b0fc8e00-8cdb-11eb-8e74-9b6972eb6995.png">
