### PR TITLE
Convert TestGrader into Mixin

### DIFF
--- a/openassessment/xblock/data_conversion.py
+++ b/openassessment/xblock/data_conversion.py
@@ -8,7 +8,7 @@ import json
 
 import six
 
-from openassessment.xblock.job_sample_grader.code_grader import TestGrader
+from openassessment.xblock.job_sample_grader.utils import get_error_response
 
 
 def convert_training_examples_list_to_dict(examples_list):
@@ -250,7 +250,9 @@ def create_submission_dict_v2(submission, prompts, staff_view=False):
         try:
             submission['answer']['parts'].append(submission['answer']['2'])
         except KeyError:
-            submission['answer']['parts'].append(TestGrader.get_error_response('staff', "Missing Staff Submission"))
+            submission['answer']['parts'].append(
+                get_error_response('staff', "Missing Staff Submission")
+                )
 
     return submission
 
@@ -268,7 +270,9 @@ def update_submission_old_format_answer(submission):
         try:
             new_answer.update({'staff_run': answer['2']})
         except KeyError:
-            new_answer.update({'staff_run': TestGrader.get_error_response('staff', "Missing Staff Submission")})
+            new_answer.update({
+                'staff_run': get_error_response('staff', "Missing Staff Submission")
+                })
 
         try:
             new_answer.update({'language': answer['0'].split('\n')[0]})

--- a/openassessment/xblock/grade_mixin.py
+++ b/openassessment/xblock/grade_mixin.py
@@ -12,8 +12,8 @@ from openassessment.assessment.errors import PeerAssessmentError, SelfAssessment
 from openassessment.xblock.data_conversion import update_submission_old_format_answer
 from xblock.core import XBlock
 
-from openassessment.xblock.job_sample_grader.code_grader import TestGrader
 from openassessment.xblock.utils import get_code_language
+from openassessment.xblock.job_sample_grader.utils import is_design_problem
 
 
 class GradeMixin(object):
@@ -142,7 +142,7 @@ class GradeMixin(object):
             'feedback_text': feedback_text,
             'has_submitted_feedback': has_submitted_feedback,
             'code_language': get_code_language(context["student_submission"]['answer']['language']),
-            'design_problem': TestGrader.is_design_problem(self.display_name),
+            'design_problem': is_design_problem(self.display_name),
             'peer_assessments': peer_assessments,
             'grade_details': self.grade_details(
                 submission_uuid,

--- a/openassessment/xblock/job_sample_grader/utils.py
+++ b/openassessment/xblock/job_sample_grader/utils.py
@@ -1,0 +1,38 @@
+"""
+Holds utility functions related to code_grader module.
+"""
+
+
+OOP_PROBLEM_NAMES = ["design-problem-1", "design-problem-2", "design-problem-3"]
+
+
+def is_design_problem(problem_name):
+    """
+    Temporary helper method to check if a coding problem is a design problem.
+    """
+    return problem_name in OOP_PROBLEM_NAMES
+
+
+def get_error_response(run_type, error):
+    """
+    Create a sample error response for a given run and the error to be displayed.
+    """
+    return {
+        'run_type': run_type,
+        'total_tests': 0,
+        'correct': 0,
+        'incorrect': 0,
+        'output': None,
+        'error': [error]
+    }
+
+
+def truncate_error_output(output):
+    """
+    Truncate error output to last 150 lines if it is very long.
+    """
+    if len(output.split('\n')) > 150:
+        actual_output = output.split("\n")[-150:]
+        actual_output.append("... Extra output Trimmed.")
+        return "\n".join(actual_output)
+    return output

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -23,7 +23,7 @@ from openassessment.xblock.course_items_listing_mixin import CourseItemsListingM
 from openassessment.xblock.data_conversion import create_prompts_list, create_rubric_dict, update_assessments_format
 from openassessment.xblock.defaults import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from openassessment.xblock.grade_mixin import GradeMixin
-from openassessment.xblock.job_sample_grader.code_grader import TestGrader
+from openassessment.xblock.job_sample_grader.code_grader import CodeGraderMixin
 from openassessment.xblock.leaderboard_mixin import LeaderboardMixin
 from openassessment.xblock.lms_mixin import LmsCompatibilityMixin
 from openassessment.xblock.message_mixin import MessageMixin
@@ -113,6 +113,7 @@ class OpenAssessmentBlock(MessageMixin,
                           StudentTrainingMixin,
                           LmsCompatibilityMixin,
                           CourseItemsListingMixin,
+                          CodeGraderMixin,
                           XBlock):
     """Displays a prompt and provides an area where students can compose a response."""
 
@@ -1171,6 +1172,6 @@ class OpenAssessmentBlock(MessageMixin,
             If the test cases details are not found, both keys will have None as the value
         """
         return {
-            'sample': TestGrader.get_test_case_count(self.display_name, 'sample'),
-            'staff': TestGrader.get_test_case_count(self.display_name, 'staff')
+            'sample': self.get_test_case_count(self.display_name, 'sample'),
+            'staff': self.get_test_case_count(self.display_name, 'staff')
         }

--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -11,11 +11,10 @@ import logging
 from openassessment.assessment.errors import PeerAssessmentInternalError
 from openassessment.workflow.errors import AssessmentWorkflowError, AssessmentWorkflowInternalError
 from openassessment.xblock.data_conversion import update_submission_old_format_answer
-from openassessment.xblock.job_sample_grader.code_grader import TestGrader
 from openassessment.xblock.resolve_dates import DISTANT_FUTURE, DISTANT_PAST
 from openassessment.xblock.utils import get_code_language, get_percentage
+from openassessment.xblock.job_sample_grader.utils import is_design_problem, get_error_response
 from xblock.core import XBlock
-
 from .user_data import get_user_preferences
 
 logger = logging.getLogger(__name__)
@@ -268,13 +267,13 @@ class StaffAreaMixin(object):
             'user_timezone': user_preferences['user_timezone'],
             'user_language': user_preferences['user_language'],
             "prompts_type": self.prompts_type,
-            "design_problem": TestGrader.is_design_problem(self.display_name)
+            "design_problem": is_design_problem(self.display_name)
         }
         if submission:
             sample_run = submission['answer']['sample_run']
             staff_run = submission['answer'].get('staff_run')
             if not staff_run:
-                staff_run = TestGrader.get_error_response('staff', 'Staff test case result is not available.')
+                staff_run = get_error_response('staff', 'Staff test case result is not available.')
             context["file_upload_type"] = self.file_upload_type
             context["staff_file_urls"] = self.get_download_urls_from_submission(submission)
             context['code_language'] = get_code_language(submission['answer']['language'])

--- a/openassessment/xblock/utils.py
+++ b/openassessment/xblock/utils.py
@@ -1,7 +1,6 @@
 """
 Grader ORA utils.
 """
-from .job_sample_grader.code_grader import TestGrader
 
 
 # Map language name to be used in template code class
@@ -34,18 +33,3 @@ def get_percentage(sample_submission, staff_submission):
         return ((float(sample_correct + staff_correct)) / (staff_total + sample_total)) * 100
     except ZeroDivisionError:
         return 0
-
-
-def grade_response(data, problem_name, add_staff_output=False):
-    """
-    Grade the response with per file test case feature.
-    """
-    data.update({'problem_name': problem_name})
-    grader = TestGrader()
-    output = grader.grade(data, add_staff_cases=add_staff_output)
-
-    sample_output = output[0]
-    if add_staff_output:
-        # If staff output is required, send the original result as it is.
-        return output
-    return sample_output


### PR DESCRIPTION
This pull request introduces the following changes:
- Renamed `TestGrader` to `CodeGraderMixin` following the convention and the task requirement.
- Extracted static helper functions from `CodeGraderMixin` into a `CodeGraderUtils` class.
    - Rationale: These static functions were being used in other parts of the code. Using a mixin to access them seemed counter-intuitive. Furthermore, this 'container' class provides a sort of namespace for better readability.
-  Moved `grade_response` utility function into `CodeGraderMixin` with some modifications. Rationale:
    - Since we no longer want to instantiate a grader instance, as the ORA block acts as a grader, this is the most convenient and intuitive way to get things working.
    - There it has a better logical affinity.

Associated Ticket: [LT-184](https://arbisoft-assessment.atlassian.net/jira/software/projects/LT/boards/2?selectedIssue=LT-184)