### PR TITLE
Add course_id, user_id to run_and_save_staff_test_cases task's kwargs

### DIFF
--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -11,6 +11,7 @@ from openassessment.fileupload.exceptions import FileUploadError
 from openassessment.workflow.errors import AssessmentWorkflowError
 from openassessment.xblock.tasks import run_and_save_staff_test_cases
 from xblock.core import XBlock
+from student.models import user_by_anonymous_id
 
 from openassessment.xblock.data_conversion import update_submission_old_format_answer
 from .job_sample_grader.utils import get_error_response, is_design_problem
@@ -133,7 +134,13 @@ class SubmissionMixin(object):
                 )
                 run_and_save_staff_test_cases.apply_async(args=[
                     str(self.scope_ids.usage_id), submission["uuid"], self.display_name
-                ])
+                ], kwargs={
+                    'course_id': student_item_dict.get('course_id'),
+                    'user_id': (
+                        user_by_anonymous_id(student_item_dict.get('student_id')).id
+                        or student_item_dict.get('student_id')
+                    )
+                })
             except api.SubmissionRequestError as err:
 
                 # Handle the case of an answer that's too long as a special case,

--- a/openassessment/xblock/tasks.py
+++ b/openassessment/xblock/tasks.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 @task(base=LoggedTask, name="run_and_save_staff_test_cases")
-def run_and_save_staff_test_cases(block_id, sub_uuid, problem_name):
+def run_and_save_staff_test_cases(block_id, sub_uuid, problem_name, **kwargs):
     """
     Celery task for running staff test cases and updating the submission
     against a given uuid.


### PR DESCRIPTION
## Description

This PR adds `course_id`, `user_id` to `run_and_save_staff_test_cases` task's kwargs.

### Reason

See https://github.com/arbisoft/litmustest-backend/pull/56. We need a way to identify which course and user this task belongs to. Looking at the kwargs is a very convenient way. It might be possible to use the Block's usage id and Submissions' uuid, but that makes things a lot inefficient and complicated.

## LIT-Ticket

[LT-277](https://arbisoft-assessment.atlassian.net/browse/LT-277?atlOrigin=eyJpIjoiNzNkOTEwNmE4Mjg4NGIwZWEwZGYzMDkxMjIzNzk2ZWQiLCJwIjoiaiJ9)

## Testing

Tested it on my local machine. `Run Code` and code submission is working as expected.