### PR TITLE
Remove extra due date

### DIFF
--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -24,7 +24,7 @@
             </h4>
         </span>
 
-        {% if submission_start %}
+        <!-- {% if submission_start %}
         <span class="step__deadline">
             {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "available August 13th, 2014 (in 5 days and 45 minutes)" #}
             {% blocktrans with start_date=submission_start|timezone:"UTC"|date:"c" time_until=submission_start|timeuntil %}
@@ -38,7 +38,7 @@
             <span id="oa_step_deadline_response" class="date ora-datetime" data-datetime="{{ due_date }}" data-string="due {date} (in {{ time_until }})" data-timezone="{{ user_timezone }}" data-language="{{ user_language }}"></span>
             {% endblocktrans %}
         </span>
-        {% endif %}
+        {% endif %} -->
         {%  block title %}
         <span class="step__status">
             <span id="oa_step_status_response" class="step__status__value">

--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -24,21 +24,6 @@
             </h4>
         </span>
 
-        <!-- {% if submission_start %}
-        <span class="step__deadline">
-            {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "available August 13th, 2014 (in 5 days and 45 minutes)" #}
-            {% blocktrans with start_date=submission_start|timezone:"UTC"|date:"c" time_until=submission_start|timeuntil %}
-            <span id="oa_step_deadline_response" class="date ora-datetime" data-datetime="{{ start_date }}" data-string="available {date} (in {{ time_until }})" data-timezone="{{ user_timezone }}" data-language="{{ user_language }}"></span>
-            {% endblocktrans %}
-        </span>
-        {% elif submission_due %}
-        <span class="step__deadline">
-            {# Translators: This string displays a date to the user, then tells them the time until that date.  Example: "due August 13th, 2014 (in 5 days and 45 minutes)" #}
-            {% blocktrans with due_date=submission_due|timezone:"UTC"|date:"c" time_until=submission_due|timeuntil %}
-            <span id="oa_step_deadline_response" class="date ora-datetime" data-datetime="{{ due_date }}" data-string="due {date} (in {{ time_until }})" data-timezone="{{ user_timezone }}" data-language="{{ user_language }}"></span>
-            {% endblocktrans %}
-        </span>
-        {% endif %} -->
         {%  block title %}
         <span class="step__status">
             <span id="oa_step_status_response" class="step__status__value">


### PR DESCRIPTION
Removed the due date message for learners.

Previous:
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/42406704/140370014-94419ad9-b132-4c56-97cd-3ae24e0e4636.png">

Updated:
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/42406704/140369726-9e07c602-05e9-49d0-833f-3673d4219255.png">


Ref [LT-331](https://arbisoft-assessment.atlassian.net/browse/LT-331?atlOrigin=eyJpIjoiM2FiYTRmMzliYjFhNDZjNWI3OGQxNDlmNGEzZmU0ZDAiLCJwIjoiaiJ9)