### PR TITLE
[LT-751] Add new images and enable network

### DIFF
--- a/openassessment/xblock/code_executor/executors/cpp_code_executors.py
+++ b/openassessment/xblock/code_executor/executors/cpp_code_executors.py
@@ -4,15 +4,15 @@ from ..interface import CodeExecutor
 
 
 class CppCodeExecutor(CompiledLanguageExecutorMixin, CodeExecutor):
-    docker_image = 'stepik/epicbox-gcc:10.2.1'
+    docker_image = 'litmustest/code-executor-gpp:12.2'
     language = 'cpp'
-    version = '20'
-    display_name = 'C++ 20 (gcc 10.2.1)'
+    version = 'g++-12.2'
+    display_name = 'C++ 20 (g++ 12.2)'
 
-    id = CodeExecutor.create_id('cpp', '20')
+    id = CodeExecutor.create_id('cpp', 'g++-12.2')
 
     SOURCE_FILE_NAME_TEMPLATE = '{name}.cpp'
     EXECUTABLE_FILE_NAME_TEMPLATE = '{name}.out'
-    COMPILE_COMMAND_TEMPLATE = 'g++ -static -o {executable_file} -std=gnu++2a {source_file}'
+    COMPILE_COMMAND_TEMPLATE = 'g++-12 -o {executable_file} -std=gnu++2a {source_file} $CPP_LD_FLAGS'
     RUN_COMMAND_STDIN_INPUT_TEMPLATE = './{executable_file}'
     RUN_COMMAND_FILE_INPUT_TEMPLATE = './{executable_file} {input_file}'

--- a/openassessment/xblock/code_executor/executors/java_code_executors.py
+++ b/openassessment/xblock/code_executor/executors/java_code_executors.py
@@ -4,12 +4,12 @@ from ..interface import CodeExecutor
 
 
 class JavaCodeExecutor(CompiledLanguageExecutorMixin, CodeExecutor):
-    docker_image = 'stepik/epicbox-java:17.0.1'
+    docker_image = 'litmustest/code-executor-openjdk:19'
     language = 'java'
-    version = '17.0.1'
-    display_name = 'Java 17'
+    version = 'openjdk-19'
+    display_name = 'Java 19 (openjdk 19)'
 
-    id = CodeExecutor.create_id('java', '17.0.1')
+    id = CodeExecutor.create_id('java', 'openjdk-19')
 
     SOURCE_FILE_NAME_TEMPLATE = 'Main.java'
     EXECUTABLE_FILE_NAME_TEMPLATE = 'Main'

--- a/openassessment/xblock/code_executor/executors/javascript_code_executors.py
+++ b/openassessment/xblock/code_executor/executors/javascript_code_executors.py
@@ -4,12 +4,12 @@ from ..interface import CodeExecutor
 
 
 class JavascriptCodeExecutor(ScriptedLanguageExecutorMixin, CodeExecutor):
-    docker_image = 'node:lts-alpine3.16'
+    docker_image = 'litmustest/code-executor-node:18.12'
     language = 'javascript'
-    version = 'nodejs-3.16'
-    display_name = 'Javascript (NodeJS 3.16)'
+    version = 'nodejs-18.12'
+    display_name = 'Javascript (NodeJS 18.12)'
 
-    id = CodeExecutor.create_id('javascript', 'nodejs-3.16')
+    id = CodeExecutor.create_id('javascript', 'nodejs-18.12')
 
     SOURCE_FILE_NAME_TEMPLATE = '{name}.js'
     RUN_COMMAND_STDIN_INPUT_TEMPLATE = 'node {source_file}'

--- a/openassessment/xblock/code_executor/executors/mixins.py
+++ b/openassessment/xblock/code_executor/executors/mixins.py
@@ -38,7 +38,13 @@ class ScriptedLanguageExecutorMixin(ABC):
             'language': cls.language,
             'version': cls.version,
             'profiles': [
-                epicbox.Profile(name=cls.id, docker_image=cls.docker_image, read_only=True,)
+                epicbox.Profile(
+                    name=cls.id,
+                    docker_image=cls.docker_image,
+                    read_only=True,
+                    network_disabled=False,
+                    user='sandbox',
+                )
             ],
         }
 
@@ -133,13 +139,16 @@ class CompiledLanguageExecutorMixin(ABC):
             'version': cls.version,
             'profiles': [
                 epicbox.Profile(
-                    name='{}-compile'.format(cls.id), docker_image=cls.docker_image,
+                    name='{}-compile'.format(cls.id),
+                    docker_image=cls.docker_image,
+                    user='sandbox',
                 ),
                 epicbox.Profile(
                     name='{}-run'.format(cls.id),
                     docker_image=cls.docker_image,
                     user='sandbox',
                     read_only=True,
+                    network_disabled=False,
                 ),
             ],
         }

--- a/openassessment/xblock/code_executor/executors/python_code_executors.py
+++ b/openassessment/xblock/code_executor/executors/python_code_executors.py
@@ -4,12 +4,12 @@ from ..interface import CodeExecutor
 
 
 class PythonCodeExecutor(ScriptedLanguageExecutorMixin, CodeExecutor):
-    docker_image = 'stepik/epicbox-python:3.10.2'
+    docker_image = 'litmustest/code-executor-python:3.12'
     language = 'python'
-    version = '3.10.2'
-    display_name = 'Python 3.10'
+    version = '3.12'
+    display_name = 'Python 3.12'
 
-    id = CodeExecutor.create_id('python', '3.10.2')
+    id = CodeExecutor.create_id('python', '3.12')
 
     SOURCE_FILE_NAME_TEMPLATE = '{name}.py'
     RUN_COMMAND_STDIN_INPUT_TEMPLATE = 'python3 {source_file}'


### PR DESCRIPTION
# Changes
## Image Size ⬇️ 

| Language | Before | Now |
| --- | --- | --- |
| python | 2.33 GB | 🟢  65.8 MB | 
| cpp | 405.6 MB | 🟢  329.21 MB |
| java | 407.37 MB | 🟢  332.55 MB |
| node | 167.29 MB | 🔴  169.3 MB |

> We added a layer in node image to create a `sandbox` user.

## Security 💪 

🟢  All code is executed by a user called `sandbox`. (We no longer run code inside a container as `root`).
🟢  During code execution FS is read-only.
🔴  Enables network usages for API questions.

## Versions 🔢 

🟢 All language versions have been updated (to the latest available alpine/ubuntu variants)

## Pre-installed Packages 📦 

| Language | Before | Now |
| --- | --- | --- |
| python | So many | requests, urllib3 | 
| cpp | None | libcurl, libjsoncpp |
| java | None | json-simple.1.1.1 |
| node | None | None |


# Ticket

[LT-751](https://arbisoft-assessment.atlassian.net/browse/LT-751)