### PR TITLE
fix: Maximum answer limit exceed

### DIFF
--- a/openassessment/xblock/job_sample_grader/code_grader.py
+++ b/openassessment/xblock/job_sample_grader/code_grader.py
@@ -23,7 +23,7 @@ from openassessment.xblock.job_sample_grader.utils import (
 from litmustest_djangoapps.core.models import AssessmentQuestionXblockMapping
 
 logger = logging.getLogger(__name__)
-SUBMISSION_MAX_SIZE = 100 * 1024  # 100 KB
+SUBMISSION_MAX_SIZE = 95 * 1024  # 95 KB
 
 ALL_CODE_EXECUTORS = sorted(
     [


### PR DESCRIPTION
Maximum size changed from 100kb to 95kb, there might be some data that we are storing that takes some space.