### PR TITLE
[LT879] Enable Fetch in Javascript

### DIFF
--- a/openassessment/xblock/code_executor/executors/javascript_code_executors.py
+++ b/openassessment/xblock/code_executor/executors/javascript_code_executors.py
@@ -14,3 +14,12 @@ class JavascriptCodeExecutor(ScriptedLanguageExecutorMixin, CodeExecutor):
     SOURCE_FILE_NAME_TEMPLATE = '{name}.js'
     RUN_COMMAND_STDIN_INPUT_TEMPLATE = 'node {source_file}'
     RUN_COMMAND_FILE_INPUT_TEMPLATE = 'node {source_file} {input_file}'
+
+
+class JavascriptCodeExecutorV18(JavascriptCodeExecutor):
+    docker_image = 'litmustest/code-executor-node:18.14.1'
+    language = 'javascript'
+    version = 'nodejs-18.14.1'
+    display_name = 'Javascript (NodeJS 18.14.1)'
+
+    id = CodeExecutor.create_id('javascript', 'nodejs-18.14.1')


### PR DESCRIPTION
In pervious version of node (18.12), the problem that students faced is with fetch. Since fetch becomes part node, it was an experimental feature, so when students use it, they experience Warning generated by node, since the warning is considered as a part of console output, making the correct output incorrect. 

In new version of node (18.14.1), the experimental warning is removed and fetch becomes part of node. This version resolves that. Currently we have both versions on our system.