### PR TITLE
fix: append design problem in question title to make it design problem

### DIFF
--- a/openassessment/xblock/job_sample_grader/utils.py
+++ b/openassessment/xblock/job_sample_grader/utils.py
@@ -11,14 +11,14 @@ def is_design_problem(usage_id=None, problem_name=None, question=None):
     Temporary helper method to check if a coding problem is a design problem.
     """
     if question:
-        return question.sub_category == "desgin_problem"
+        return question.sub_category == "design_problem"
 
     question = Question.get_by_usage_key(
         usage_key=str(usage_id),
         fallback_title=problem_name
     )
     problem_name_in_lower = question.title.lower()
-    return question.sub_category == "desgin_problem" or problem_name_in_lower.endswith('design problem')
+    return question.sub_category == "design_problem" or problem_name_in_lower.endswith('design problem')
 
 def get_error_response(run_type, error, is_design_problem=False):
     """


### PR DESCRIPTION
Now we can select design problem as a sub category of coding question to make it into design problem. We don't have to append design problem at the end of the question title. For backward compatibility, design problem can also be created by appending the design problem at the end of the title.