### PR TITLE
feat: add ReactJS and Text language support

### DIFF
--- a/openassessment/xblock/code_executor/constants.py
+++ b/openassessment/xblock/code_executor/constants.py
@@ -77,4 +77,20 @@ LIMITS = {
         'memory': 256,
         'processes': -1,
     },
+
+    # Framework
+    'reactjs:reactjs-19-node-24': {
+        'cputime': 20,
+        'realtime': 25,
+        'memory': 256,
+        'processes': -1,
+    },
+
+    # Text Executor
+    'text:alpine-3.21': {
+        'cputime': 20,
+        'realtime': 25,
+        'memory': 256,
+        'processes': -1,
+    },
 }

--- a/openassessment/xblock/code_executor/executors/alpine_text_executor.py
+++ b/openassessment/xblock/code_executor/executors/alpine_text_executor.py
@@ -1,0 +1,16 @@
+from .mixins import ScriptedLanguageExecutorMixin
+
+from ..interface import CodeExecutor
+
+
+class AlpineTextExecutor(ScriptedLanguageExecutorMixin, CodeExecutor):
+    docker_image = 'litmustest/text-executor-alpine:3.21'
+    language = 'text'
+    version = 'alpine-3.21'
+    display_name = 'Text Paragraph'
+
+    id = CodeExecutor.create_id('text', 'alpine-3.21')
+
+    SOURCE_FILE_NAME_TEMPLATE = '{name}.txt'
+    RUN_COMMAND_STDIN_INPUT_TEMPLATE = 'cat {source_file}'
+    RUN_COMMAND_FILE_INPUT_TEMPLATE = 'cat {source_file}'

--- a/openassessment/xblock/code_executor/executors/react_code_executor.py
+++ b/openassessment/xblock/code_executor/executors/react_code_executor.py
@@ -1,0 +1,16 @@
+from .mixins import ScriptedLanguageExecutorMixin
+
+from ..interface import CodeExecutor
+
+
+class ReactCodeExecutorV24(ScriptedLanguageExecutorMixin, CodeExecutor):
+    docker_image = 'litmustest/react-code-executor:node-24-slim'
+    language = 'reactjs'
+    version = 'reactjs-19-node-24'
+    display_name = 'React (ReactJS 19 + NodeJS 24 + tsx)'
+
+    id = CodeExecutor.create_id('reactjs', 'reactjs-19-node-24')
+
+    SOURCE_FILE_NAME_TEMPLATE = 'solution.jsx'
+    RUN_COMMAND_STDIN_INPUT_TEMPLATE = 'tsx test-runner.jsx'
+    RUN_COMMAND_FILE_INPUT_TEMPLATE = 'tsx test-runner.jsx {input_file}'

--- a/openassessment/xblock/static/js/src/lms/oa_response.js
+++ b/openassessment/xblock/static/js/src/lms/oa_response.js
@@ -779,6 +779,41 @@ func main() {
     }
 }
             `.trim(),
+
+            reactjs: `
+import React, { useState } from 'react';
+
+export default function Solution({ fileContent }) {
+  // 'fileContent' contains the raw string data read from the test case file.
+  // We can parse it into an array of lines, removing any empty ones.
+  const lines = fileContent ? fileContent.split('\\n').filter(Boolean) : [];
+
+  return (
+    <div className="solution-container">
+      <h1>Hello World</h1>
+      
+      {/* Write your code here. */}
+      
+      <div className="output">
+        <h3>Input Data:</h3>
+        <ul>
+          {lines.map((line, index) => (
+            <li key={index} data-testid={\`input-line-\${index}\`}>
+              {line}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+              `.trim(),
+
+            text: `
+# Start writing your text response below.
+# You may use plain text, Markdown, or any formatting you prefer.
+# No code execution is required for this language option.
+              `.trim(),
         };
 
         var editor_textarea = $('.response__submission .submission__answer__part__text__value', this.element);
@@ -826,6 +861,12 @@ func main() {
       }
       else if (language == "javascript"){
         this.codeEditor.setOption("mode", "text/javascript");
+      }
+      else if (language == "reactjs"){
+        this.codeEditor.setOption("mode", "text/javascript");
+      }
+      else if (language == "text"){
+        this.codeEditor.setOption("mode", "text/plain");
       }
     },
 

--- a/openassessment/xblock/utils.py
+++ b/openassessment/xblock/utils.py
@@ -16,6 +16,8 @@ CODE_LANGUAGES = {
     'php': 'language-php',
     'dotnet': 'language-dotnet',
     'go': 'language-go',
+    'reactjs': 'language-nodejs',
+    'text': 'language-markup',
 }
 
 


### PR DESCRIPTION
Adds two new language options for ORA code exercises:

- ReactJS (ReactJS 19 + NodeJS 24): Full React component support with JSX syntax highlighting and starter template
- Text: Simple text response option for non-code submissions

Changes:
- Add ReactCodeExecutor and AlpineTextExecutor executor classes
- Add execution limits for new language versions in constants.py
- Add starter code templates and editor mode handling in oa_response.js
- Register new languages in CODE_LANGUAGES mapping